### PR TITLE
feat: add task function worker node affinity

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -83,6 +83,10 @@ jobs:
     needs: build-release
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -108,23 +112,15 @@ jobs:
       - name: Publish Release
         if: ${{ contains(github.ref_name, '-') == false }}
         run: cd dist && npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Release Candidate
         if: ${{ contains(github.ref_name, '-rc') == true }}
         run: cd dist && npm publish --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Beta Release
         if: ${{ contains(github.ref_name, '-beta') == true }}
         run: cd dist && npm publish --tag beta
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Alpha Release
         if: ${{ contains(github.ref_name, '-alpha') == true }}
         run: cd dist && npm publish --tag alpha
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Please consult our [general guidelines](#general-guidelines).
 - Support for abortable task function ✔
 - Support for multiple task functions with per task function queuing priority
   and tasks distribution strategy ✔
+- Support for worker node affinity per task function ✔
 - Support for task functions
   [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete)
   operations at runtime ✔

--- a/docs/api.md
+++ b/docs/api.md
@@ -91,8 +91,22 @@ This method is available on both pool implementations and returns a boolean.
 `name` (mandatory) The task function name.\
 `fn` (mandatory) The task function
 `(data?: Data) => Response | Promise<Response>` or task function object
-`{ taskFunction: (data?: Data) => Response | Promise<Response>, priority?: number, strategy?: WorkerChoiceStrategy }`.
-Priority range is the same as Unix nice levels.
+`{ taskFunction: (data?: Data) => Response | Promise<Response>, priority?: number, strategy?: WorkerChoiceStrategy, workerNodeKeys?: number[] }`.
+Priority range is the same as Unix nice levels. `workerNodeKeys` is an array of
+worker node keys to restrict task execution to specific workers (worker node
+affinity).
+
+#### Worker Node Affinity Notes
+
+- Worker node keys are validated at registration time against the pool's maximum
+  size (`maximumNumberOfWorkers ?? minimumNumberOfWorkers`).
+- The number of worker node keys cannot exceed the pool's maximum size
+  (`maximumNumberOfWorkers ?? minimumNumberOfWorkers`).
+- In dynamic pools, you can reference worker node keys up to the maximum pool
+  size. Workers that don't exist yet are automatically created when a task
+  targeting them is executed.
+- At execution time, if no specified worker is ready, selection retries until
+  one becomes available or retries are exhausted.
 
 This method is available on both pool implementations and returns a boolean
 promise.
@@ -225,9 +239,12 @@ An object with these properties:
 ### `class YourWorker extends ThreadWorker`
 
 `taskFunctions` (mandatory) The task function or task functions object
-`Record<string, (data?: Data) => Response | Promise<Response> | { taskFunction: (data?: Data) => Response | Promise<Response>, priority?: number, strategy?: WorkerChoiceStrategy }>`
+`Record<string, (data?: Data) => Response | Promise<Response> | { taskFunction: (data?: Data) => Response | Promise<Response>, priority?: number, strategy?: WorkerChoiceStrategy, workerNodeKeys?: number[] }>`
 that you want to execute on the worker. Priority range is the same as Unix nice
-levels.\
+levels. `workerNodeKeys` is an array of worker node keys to restrict task
+execution to specific workers (worker node affinity). See
+[Worker Node Affinity Notes](#worker-node-affinity-notes) above for validation
+behavior.\
 `opts` (optional) An object with these properties:
 
 - `killBehavior` (optional) - Dictates if your worker will be deleted in case a
@@ -270,8 +287,11 @@ This method is available on both worker implementations and returns
 `name` (mandatory) The task function name.\
 `fn` (mandatory) The task function
 `(data?: Data) => Response | Promise<Response>` or task function object
-`{ taskFunction: (data?: Data) => Response | Promise<Response>, priority?: number, strategy?: WorkerChoiceStrategy }`.
-Priority range is the same as Unix nice levels.
+`{ taskFunction: (data?: Data) => Response | Promise<Response>, priority?: number, strategy?: WorkerChoiceStrategy, workerNodeKeys?: number[] }`.
+Priority range is the same as Unix nice levels. `workerNodeKeys` is an array of
+worker node keys to restrict task execution to specific workers (worker node
+affinity). See [Worker Node Affinity Notes](#worker-node-affinity-notes) above
+for validation behavior.
 
 This method is available on both worker implementations and returns
 `{ status: boolean, error?: Error }`.

--- a/src/pools/abstract-pool.ts
+++ b/src/pools/abstract-pool.ts
@@ -2212,6 +2212,14 @@ export abstract class AbstractPool<
     if (ready == null || !ready) {
       throw new Error(`Worker ${workerId?.toString()} failed to initialize`)
     }
+    const maxPoolSize =
+      this.maximumNumberOfWorkers ?? this.minimumNumberOfWorkers
+    for (const taskFunctionProperties of taskFunctionsProperties ?? []) {
+      checkValidWorkerNodeKeys(
+        taskFunctionProperties.workerNodeKeys,
+        maxPoolSize,
+      )
+    }
     const workerNodeKey = this.getWorkerNodeKeyByWorkerId(workerId)
     const workerNode = this.workerNodes[workerNodeKey]
     workerNode.info.ready = ready

--- a/src/pools/abstract-pool.ts
+++ b/src/pools/abstract-pool.ts
@@ -1577,8 +1577,8 @@ export abstract class AbstractPool<
   private chooseWorkerNode(name?: string): number {
     const workerNodeKeysSet = this.getTaskFunctionWorkerNodeKeysSet(name)
     if (workerNodeKeysSet != null) {
-      const maxPoolSize =
-        this.maximumNumberOfWorkers ?? this.minimumNumberOfWorkers
+      const maxPoolSize = this.maximumNumberOfWorkers ??
+        this.minimumNumberOfWorkers
       const targetSize = max(...workerNodeKeysSet) + 1
       while (
         this.started &&

--- a/src/pools/abstract-pool.ts
+++ b/src/pools/abstract-pool.ts
@@ -45,6 +45,7 @@ import {
   checkValidPriority,
   checkValidTasksQueueOptions,
   checkValidWorkerChoiceStrategy,
+  checkValidWorkerNodeKeys,
   getDefaultTasksQueueOptions,
   updateEluWorkerUsage,
   updateRunTimeWorkerUsage,
@@ -842,8 +843,8 @@ export abstract class AbstractPool<
   private async sendTaskFunctionOperationToWorkers(
     message: MessageValue<Data>,
   ): Promise<boolean> {
-    const targetWorkerNodeKeys = [...this.workerNodes.keys()]
-    if (targetWorkerNodeKeys.length === 0) {
+    const targetWorkerNodeCount = this.workerNodes.length
+    if (targetWorkerNodeCount === 0) {
       return true
     }
     const responsesReceived: MessageValue<Response>[] = []
@@ -853,14 +854,14 @@ export abstract class AbstractPool<
       reject: (reason?: unknown) => void,
     ): void => {
       this.checkMessageWorkerId(message)
+      const workerNodeKey = this.getWorkerNodeKeyByWorkerId(message.workerId)
       if (
         message.taskFunctionOperationStatus != null &&
-        targetWorkerNodeKeys.includes(
-          this.getWorkerNodeKeyByWorkerId(message.workerId),
-        )
+        workerNodeKey >= 0 &&
+        workerNodeKey < targetWorkerNodeCount
       ) {
         responsesReceived.push(message)
-        if (responsesReceived.length >= targetWorkerNodeKeys.length) {
+        if (responsesReceived.length >= targetWorkerNodeCount) {
           if (
             responsesReceived.every(
               (msg) => msg.taskFunctionOperationStatus === true,
@@ -883,19 +884,20 @@ export abstract class AbstractPool<
       }
     }
     let listener: ((message: MessageValue<Response>) => void) | undefined
+    const workerNodeKeys = [...this.workerNodes.keys()]
     try {
       return await new Promise<boolean>((resolve, reject) => {
         listener = (message: MessageValue<Response>) => {
           taskFunctionOperationsListener(message, resolve, reject)
         }
-        for (const workerNodeKey of targetWorkerNodeKeys) {
+        for (const workerNodeKey of workerNodeKeys) {
           this.registerWorkerMessageListener(workerNodeKey, listener)
           this.sendToWorker(workerNodeKey, message)
         }
       })
     } finally {
       if (listener != null) {
-        for (const workerNodeKey of targetWorkerNodeKeys) {
+        for (const workerNodeKey of workerNodeKeys) {
           this.deregisterWorkerMessageListener(workerNodeKey, listener)
         }
       }
@@ -928,6 +930,10 @@ export abstract class AbstractPool<
     }
     checkValidPriority(fn.priority)
     checkValidWorkerChoiceStrategy(fn.strategy)
+    checkValidWorkerNodeKeys(
+      fn.workerNodeKeys,
+      this.maximumNumberOfWorkers ?? this.minimumNumberOfWorkers,
+    )
     const opResult = await this.sendTaskFunctionOperationToWorkers({
       taskFunctionOperation: 'add',
       taskFunctionProperties: buildTaskFunctionProperties(name, fn),
@@ -1055,6 +1061,26 @@ export abstract class AbstractPool<
       (taskFunctionProperties: TaskFunctionProperties) =>
         taskFunctionProperties.name === name,
     )?.strategy
+  }
+
+  /**
+   * Gets task function worker node keys affinity set, if any.
+   * @param name - The task function name.
+   * @returns The task function worker node keys affinity set, or `undefined` if not defined.
+   */
+  private readonly getTaskFunctionWorkerNodeKeysSet = (
+    name?: string,
+  ): ReadonlySet<number> | undefined => {
+    name = name ?? DEFAULT_TASK_NAME
+    const taskFunctionsProperties = this.listTaskFunctionsProperties()
+    if (name === DEFAULT_TASK_NAME) {
+      name = taskFunctionsProperties[1]?.name
+    }
+    const workerNodeKeys = taskFunctionsProperties.find(
+      (taskFunctionProperties: TaskFunctionProperties) =>
+        taskFunctionProperties.name === name,
+    )?.workerNodeKeys
+    return workerNodeKeys != null ? new Set(workerNodeKeys) : undefined
   }
 
   /**
@@ -1549,7 +1575,20 @@ export abstract class AbstractPool<
    * @returns The chosen worker node key.
    */
   private chooseWorkerNode(name?: string): number {
-    if (this.shallCreateDynamicWorker()) {
+    const workerNodeKeysSet = this.getTaskFunctionWorkerNodeKeysSet(name)
+    if (workerNodeKeysSet != null) {
+      const maxPoolSize =
+        this.maximumNumberOfWorkers ?? this.minimumNumberOfWorkers
+      const targetSize = max(...workerNodeKeysSet) + 1
+      while (
+        this.started &&
+        !this.destroying &&
+        this.workerNodes.length < targetSize &&
+        this.workerNodes.length < maxPoolSize
+      ) {
+        this.createAndSetupDynamicWorkerNode()
+      }
+    } else if (this.shallCreateDynamicWorker()) {
       const workerNodeKey = this.createAndSetupDynamicWorkerNode()
       if (
         this.workerChoiceStrategiesContext?.getPolicy().dynamicWorkerUsage ===
@@ -1560,6 +1599,7 @@ export abstract class AbstractPool<
     }
     return this.workerChoiceStrategiesContext!.execute(
       this.getTaskFunctionWorkerChoiceStrategy(name),
+      workerNodeKeysSet,
     )
   }
 

--- a/src/pools/abstract-pool.ts
+++ b/src/pools/abstract-pool.ts
@@ -2212,8 +2212,8 @@ export abstract class AbstractPool<
     if (ready == null || !ready) {
       throw new Error(`Worker ${workerId?.toString()} failed to initialize`)
     }
-    const maxPoolSize =
-      this.maximumNumberOfWorkers ?? this.minimumNumberOfWorkers
+    const maxPoolSize = this.maximumNumberOfWorkers ??
+      this.minimumNumberOfWorkers
     for (const taskFunctionProperties of taskFunctionsProperties ?? []) {
       checkValidWorkerNodeKeys(
         taskFunctionProperties.workerNodeKeys,

--- a/src/pools/selection-strategies/abstract-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/abstract-worker-choice-strategy.ts
@@ -102,7 +102,7 @@ export abstract class AbstractWorkerChoiceStrategy<
 
   /** @inheritDoc */
   public abstract choose(
-    workerNodeKeysSet?: ReadonlySet<number>
+    workerNodeKeysSet?: ReadonlySet<number>,
   ): number | undefined
 
   /** @inheritDoc */
@@ -164,7 +164,7 @@ export abstract class AbstractWorkerChoiceStrategy<
    * @returns The worker node key if ready, `undefined` otherwise.
    */
   protected getSingleWorkerNodeKey(
-    workerNodeKeysSet: ReadonlySet<number>
+    workerNodeKeysSet: ReadonlySet<number>,
   ): number | undefined {
     const [workerNodeKey] = workerNodeKeysSet
     return this.isWorkerNodeReady(workerNodeKey) ? workerNodeKey : undefined
@@ -179,7 +179,7 @@ export abstract class AbstractWorkerChoiceStrategy<
    */
   protected isWorkerNodeEligible(
     workerNodeKey: number,
-    workerNodeKeysSet?: ReadonlySet<number>
+    workerNodeKeysSet?: ReadonlySet<number>,
   ): boolean {
     return (
       this.isWorkerNodeReady(workerNodeKey) &&

--- a/src/pools/selection-strategies/fair-share-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/fair-share-worker-choice-strategy.ts
@@ -77,9 +77,9 @@ export class FairShareWorkerChoiceStrategy<
   }
 
   /** @inheritDoc */
-  public choose(): number | undefined {
+  public choose(workerNodeKeysSet?: ReadonlySet<number>): number | undefined {
     this.setPreviousWorkerNodeKey(this.nextWorkerNodeKey)
-    this.nextWorkerNodeKey = this.fairShareNextWorkerNodeKey()
+    this.nextWorkerNodeKey = this.fairShareNextWorkerNodeKey(workerNodeKeysSet)
     return this.nextWorkerNodeKey
   }
 
@@ -96,19 +96,19 @@ export class FairShareWorkerChoiceStrategy<
     return true
   }
 
-  private fairShareNextWorkerNodeKey(): number | undefined {
+  private fairShareNextWorkerNodeKey(
+    workerNodeKeysSet?: ReadonlySet<number>,
+  ): number | undefined {
+    if (workerNodeKeysSet?.size === 0) {
+      return undefined
+    }
+    if (workerNodeKeysSet?.size === 1) {
+      return this.getSingleWorkerNodeKey(workerNodeKeysSet)
+    }
     const chosenWorkerNodeKey = this.pool.workerNodes.reduce(
       (minWorkerNodeKey: number, workerNode, workerNodeKey, workerNodes) => {
-        if (!this.isWorkerNodeReady(workerNodeKey)) {
+        if (!this.isWorkerNodeEligible(workerNodeKey, workerNodeKeysSet)) {
           return minWorkerNodeKey
-        }
-        if (minWorkerNodeKey === -1) {
-          workerNode.strategyData = {
-            ...workerNode.strategyData,
-            virtualTaskEndTimestamp: this
-              .computeWorkerNodeVirtualTaskEndTimestamp(workerNodeKey),
-          }
-          return workerNodeKey
         }
         if (workerNode.strategyData?.virtualTaskEndTimestamp == null) {
           workerNode.strategyData = {
@@ -116,6 +116,9 @@ export class FairShareWorkerChoiceStrategy<
             virtualTaskEndTimestamp: this
               .computeWorkerNodeVirtualTaskEndTimestamp(workerNodeKey),
           }
+        }
+        if (minWorkerNodeKey === -1) {
+          return workerNodeKey
         }
         return workerNode.strategyData.virtualTaskEndTimestamp! <
             workerNodes[minWorkerNodeKey].strategyData!.virtualTaskEndTimestamp!

--- a/src/pools/selection-strategies/interleaved-weighted-round-robin-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/interleaved-weighted-round-robin-worker-choice-strategy.ts
@@ -85,7 +85,13 @@ export class InterleavedWeightedRoundRobinWorkerChoiceStrategy<
   }
 
   /** @inheritDoc */
-  public choose(): number | undefined {
+  public choose(workerNodeKeysSet?: ReadonlySet<number>): number | undefined {
+    if (workerNodeKeysSet?.size === 0) {
+      return undefined
+    }
+    if (workerNodeKeysSet?.size === 1) {
+      return this.getSingleWorkerNodeKey(workerNodeKeysSet)
+    }
     for (
       let roundIndex = this.roundId;
       roundIndex < this.roundWeights.length;
@@ -106,7 +112,7 @@ export class InterleavedWeightedRoundRobinWorkerChoiceStrategy<
         }
         const workerWeight = this.opts!.weights![workerNodeKey]
         if (
-          this.isWorkerNodeReady(workerNodeKey) &&
+          this.isWorkerNodeEligible(workerNodeKey, workerNodeKeysSet) &&
           workerWeight >= this.roundWeights[roundIndex] &&
           this.workerNodeVirtualTaskExecutionTime < workerWeight
         ) {
@@ -118,6 +124,7 @@ export class InterleavedWeightedRoundRobinWorkerChoiceStrategy<
           return this.nextWorkerNodeKey
         }
       }
+      this.workerNodeId = 0
     }
     this.interleavedWeightedRoundRobinNextWorkerNodeId()
     return undefined

--- a/src/pools/selection-strategies/least-busy-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/least-busy-worker-choice-strategy.ts
@@ -62,9 +62,9 @@ export class LeastBusyWorkerChoiceStrategy<
   }
 
   /** @inheritDoc */
-  public choose(): number | undefined {
+  public choose(workerNodeKeysSet?: ReadonlySet<number>): number | undefined {
     this.setPreviousWorkerNodeKey(this.nextWorkerNodeKey)
-    this.nextWorkerNodeKey = this.leastBusyNextWorkerNodeKey()
+    this.nextWorkerNodeKey = this.leastBusyNextWorkerNodeKey(workerNodeKeysSet)
     return this.nextWorkerNodeKey
   }
 
@@ -73,10 +73,18 @@ export class LeastBusyWorkerChoiceStrategy<
     return true
   }
 
-  private leastBusyNextWorkerNodeKey(): number | undefined {
+  private leastBusyNextWorkerNodeKey(
+    workerNodeKeysSet?: ReadonlySet<number>,
+  ): number | undefined {
+    if (workerNodeKeysSet?.size === 0) {
+      return undefined
+    }
+    if (workerNodeKeysSet?.size === 1) {
+      return this.getSingleWorkerNodeKey(workerNodeKeysSet)
+    }
     const chosenWorkerNodeKey = this.pool.workerNodes.reduce(
       (minWorkerNodeKey: number, workerNode, workerNodeKey, workerNodes) => {
-        if (!this.isWorkerNodeReady(workerNodeKey)) {
+        if (!this.isWorkerNodeEligible(workerNodeKey, workerNodeKeysSet)) {
           return minWorkerNodeKey
         }
         if (minWorkerNodeKey === -1) {

--- a/src/pools/selection-strategies/least-elu-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/least-elu-worker-choice-strategy.ts
@@ -76,6 +76,12 @@ export class LeastEluWorkerChoiceStrategy<
   private leastEluNextWorkerNodeKey(
     workerNodeKeysSet?: ReadonlySet<number>,
   ): number | undefined {
+    if (workerNodeKeysSet?.size === 0) {
+      return undefined
+    }
+    if (workerNodeKeysSet?.size === 1) {
+      return this.getSingleWorkerNodeKey(workerNodeKeysSet)
+    }
     const chosenWorkerNodeKey = this.pool.workerNodes.reduce(
       (minWorkerNodeKey: number, workerNode, workerNodeKey, workerNodes) => {
         if (!this.isWorkerNodeEligible(workerNodeKey, workerNodeKeysSet)) {

--- a/src/pools/selection-strategies/least-elu-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/least-elu-worker-choice-strategy.ts
@@ -62,9 +62,9 @@ export class LeastEluWorkerChoiceStrategy<
   }
 
   /** @inheritDoc */
-  public choose(): number | undefined {
+  public choose(workerNodeKeysSet?: ReadonlySet<number>): number | undefined {
     this.setPreviousWorkerNodeKey(this.nextWorkerNodeKey)
-    this.nextWorkerNodeKey = this.leastEluNextWorkerNodeKey()
+    this.nextWorkerNodeKey = this.leastEluNextWorkerNodeKey(workerNodeKeysSet)
     return this.nextWorkerNodeKey
   }
 
@@ -73,10 +73,12 @@ export class LeastEluWorkerChoiceStrategy<
     return true
   }
 
-  private leastEluNextWorkerNodeKey(): number | undefined {
+  private leastEluNextWorkerNodeKey(
+    workerNodeKeysSet?: ReadonlySet<number>,
+  ): number | undefined {
     const chosenWorkerNodeKey = this.pool.workerNodes.reduce(
       (minWorkerNodeKey: number, workerNode, workerNodeKey, workerNodes) => {
-        if (!this.isWorkerNodeReady(workerNodeKey)) {
+        if (!this.isWorkerNodeEligible(workerNodeKey, workerNodeKeysSet)) {
           return minWorkerNodeKey
         }
         if (minWorkerNodeKey === -1) {

--- a/src/pools/selection-strategies/least-used-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/least-used-worker-choice-strategy.ts
@@ -43,9 +43,9 @@ export class LeastUsedWorkerChoiceStrategy<
   }
 
   /** @inheritDoc */
-  public choose(): number | undefined {
+  public choose(workerNodeKeysSet?: ReadonlySet<number>): number | undefined {
     this.setPreviousWorkerNodeKey(this.nextWorkerNodeKey)
-    this.nextWorkerNodeKey = this.leastUsedNextWorkerNodeKey()
+    this.nextWorkerNodeKey = this.leastUsedNextWorkerNodeKey(workerNodeKeysSet)
     return this.nextWorkerNodeKey
   }
 
@@ -54,10 +54,18 @@ export class LeastUsedWorkerChoiceStrategy<
     return true
   }
 
-  private leastUsedNextWorkerNodeKey(): number | undefined {
+  private leastUsedNextWorkerNodeKey(
+    workerNodeKeysSet?: ReadonlySet<number>,
+  ): number | undefined {
+    if (workerNodeKeysSet?.size === 0) {
+      return undefined
+    }
+    if (workerNodeKeysSet?.size === 1) {
+      return this.getSingleWorkerNodeKey(workerNodeKeysSet)
+    }
     const chosenWorkerNodeKey = this.pool.workerNodes.reduce(
       (minWorkerNodeKey: number, workerNode, workerNodeKey, workerNodes) => {
-        if (!this.isWorkerNodeReady(workerNodeKey)) {
+        if (!this.isWorkerNodeEligible(workerNodeKey, workerNodeKeysSet)) {
           return minWorkerNodeKey
         }
         if (minWorkerNodeKey === -1) {

--- a/src/pools/selection-strategies/round-robin-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/round-robin-worker-choice-strategy.ts
@@ -45,13 +45,17 @@ export class RoundRobinWorkerChoiceStrategy<
   }
 
   /** @inheritDoc */
-  public choose(): number | undefined {
+  public choose(workerNodeKeysSet?: ReadonlySet<number>): number | undefined {
     this.setPreviousWorkerNodeKey(this.nextWorkerNodeKey)
-    this.roundRobinNextWorkerNodeKey()
-    if (!this.isWorkerNodeReady(this.nextWorkerNodeKey!)) {
+    const chosenWorkerNodeKey =
+      this.roundRobinNextWorkerNodeKey(workerNodeKeysSet)
+    if (chosenWorkerNodeKey == null) {
       return undefined
     }
-    return this.checkWorkerNodeKey(this.nextWorkerNodeKey)
+    if (!this.isWorkerNodeEligible(chosenWorkerNodeKey, workerNodeKeysSet)) {
+      return undefined
+    }
+    return this.checkWorkerNodeKey(chosenWorkerNodeKey)
   }
 
   /** @inheritDoc */
@@ -73,11 +77,31 @@ export class RoundRobinWorkerChoiceStrategy<
     return true
   }
 
-  private roundRobinNextWorkerNodeKey(): number | undefined {
-    this.nextWorkerNodeKey =
-      this.nextWorkerNodeKey === this.pool.workerNodes.length - 1
-        ? 0
-        : (this.nextWorkerNodeKey ?? this.previousWorkerNodeKey) + 1
-    return this.nextWorkerNodeKey
+  private roundRobinNextWorkerNodeKey(
+    workerNodeKeysSet?: ReadonlySet<number>,
+  ): number | undefined {
+    if (workerNodeKeysSet == null) {
+      this.nextWorkerNodeKey = this.getRoundRobinNextWorkerNodeKey()
+      return this.nextWorkerNodeKey
+    }
+    if (workerNodeKeysSet.size === 0) {
+      return undefined
+    }
+    if (workerNodeKeysSet.size === 1) {
+      const selectedWorkerNodeKey =
+        this.getSingleWorkerNodeKey(workerNodeKeysSet)
+      if (selectedWorkerNodeKey != null) {
+        this.nextWorkerNodeKey = selectedWorkerNodeKey
+      }
+      return selectedWorkerNodeKey
+    }
+    const workerNodesCount = this.pool.workerNodes.length
+    for (let i = 0; i < workerNodesCount; i++) {
+      this.nextWorkerNodeKey = this.getRoundRobinNextWorkerNodeKey()
+      if (workerNodeKeysSet.has(this.nextWorkerNodeKey)) {
+        return this.nextWorkerNodeKey
+      }
+    }
+    return undefined
   }
 }

--- a/src/pools/selection-strategies/round-robin-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/round-robin-worker-choice-strategy.ts
@@ -47,8 +47,9 @@ export class RoundRobinWorkerChoiceStrategy<
   /** @inheritDoc */
   public choose(workerNodeKeysSet?: ReadonlySet<number>): number | undefined {
     this.setPreviousWorkerNodeKey(this.nextWorkerNodeKey)
-    const chosenWorkerNodeKey =
-      this.roundRobinNextWorkerNodeKey(workerNodeKeysSet)
+    const chosenWorkerNodeKey = this.roundRobinNextWorkerNodeKey(
+      workerNodeKeysSet,
+    )
     if (chosenWorkerNodeKey == null) {
       return undefined
     }
@@ -88,8 +89,9 @@ export class RoundRobinWorkerChoiceStrategy<
       return undefined
     }
     if (workerNodeKeysSet.size === 1) {
-      const selectedWorkerNodeKey =
-        this.getSingleWorkerNodeKey(workerNodeKeysSet)
+      const selectedWorkerNodeKey = this.getSingleWorkerNodeKey(
+        workerNodeKeysSet,
+      )
       if (selectedWorkerNodeKey != null) {
         this.nextWorkerNodeKey = selectedWorkerNodeKey
       }

--- a/src/pools/selection-strategies/selection-strategies-types.ts
+++ b/src/pools/selection-strategies/selection-strategies-types.ts
@@ -207,12 +207,14 @@ export interface IWorkerChoiceStrategy {
   readonly update: (workerNodeKey: number) => boolean
   /**
    * Chooses a worker node in the pool and returns its key.
-   * If no worker nodes are not eligible, `undefined` is returned.
-   * If `undefined` is returned, the caller retry.
+   * If no worker nodes are eligible, `undefined` is returned and the caller retries.
    *
+   * @param workerNodeKeysSet - The worker node keys affinity set. If undefined, all workers are eligible.
    * @returns The worker node key or `undefined`.
    */
-  readonly choose: () => number | undefined
+  readonly choose: (
+    workerNodeKeysSet?: ReadonlySet<number>
+  ) => number | undefined
   /**
    * Removes the worker node key from strategy internals.
    *

--- a/src/pools/selection-strategies/selection-strategies-types.ts
+++ b/src/pools/selection-strategies/selection-strategies-types.ts
@@ -213,7 +213,7 @@ export interface IWorkerChoiceStrategy {
    * @returns The worker node key or `undefined`.
    */
   readonly choose: (
-    workerNodeKeysSet?: ReadonlySet<number>
+    workerNodeKeysSet?: ReadonlySet<number>,
   ) => number | undefined
   /**
    * Removes the worker node key from strategy internals.

--- a/src/pools/selection-strategies/weighted-round-robin-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/weighted-round-robin-worker-choice-strategy.ts
@@ -73,8 +73,9 @@ export class WeightedRoundRobinWorkerChoiceStrategy<
   /** @inheritDoc */
   public choose(workerNodeKeysSet?: ReadonlySet<number>): number | undefined {
     this.setPreviousWorkerNodeKey(this.nextWorkerNodeKey)
-    const chosenWorkerNodeKey =
-      this.weightedRoundRobinNextWorkerNodeKey(workerNodeKeysSet)
+    const chosenWorkerNodeKey = this.weightedRoundRobinNextWorkerNodeKey(
+      workerNodeKeysSet,
+    )
     if (chosenWorkerNodeKey == null) {
       return undefined
     }
@@ -126,8 +127,9 @@ export class WeightedRoundRobinWorkerChoiceStrategy<
       return undefined
     }
     if (workerNodeKeysSet.size === 1) {
-      const selectedWorkerNodeKey =
-        this.getSingleWorkerNodeKey(workerNodeKeysSet)
+      const selectedWorkerNodeKey = this.getSingleWorkerNodeKey(
+        workerNodeKeysSet,
+      )
       if (selectedWorkerNodeKey != null) {
         this.nextWorkerNodeKey = selectedWorkerNodeKey
         this.workerNodeVirtualTaskExecutionTime = 0
@@ -136,8 +138,7 @@ export class WeightedRoundRobinWorkerChoiceStrategy<
     }
     const workerNodeKey = this.nextWorkerNodeKey ?? this.previousWorkerNodeKey
     if (!workerNodeKeysSet.has(workerNodeKey)) {
-      this.nextWorkerNodeKey =
-        this.findEligibleWorkerNodeKey(workerNodeKeysSet)
+      this.nextWorkerNodeKey = this.findEligibleWorkerNodeKey(workerNodeKeysSet)
       this.workerNodeVirtualTaskExecutionTime = 0
       return this.nextWorkerNodeKey
     }
@@ -148,8 +149,7 @@ export class WeightedRoundRobinWorkerChoiceStrategy<
         this.getWorkerNodeTaskWaitTime(workerNodeKey) +
         this.getWorkerNodeTaskRunTime(workerNodeKey)
     } else {
-      this.nextWorkerNodeKey =
-        this.findEligibleWorkerNodeKey(workerNodeKeysSet)
+      this.nextWorkerNodeKey = this.findEligibleWorkerNodeKey(workerNodeKeysSet)
       this.workerNodeVirtualTaskExecutionTime = 0
     }
     return this.nextWorkerNodeKey

--- a/src/pools/selection-strategies/weighted-round-robin-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/weighted-round-robin-worker-choice-strategy.ts
@@ -114,6 +114,7 @@ export class WeightedRoundRobinWorkerChoiceStrategy<
       const workerNodeKey = this.nextWorkerNodeKey ?? this.previousWorkerNodeKey
       const workerWeight = this.opts!.weights![workerNodeKey]
       if (this.workerNodeVirtualTaskExecutionTime < workerWeight) {
+        this.nextWorkerNodeKey = workerNodeKey
         this.workerNodeVirtualTaskExecutionTime +=
           this.getWorkerNodeTaskWaitTime(workerNodeKey) +
           this.getWorkerNodeTaskRunTime(workerNodeKey)

--- a/src/pools/selection-strategies/weighted-round-robin-worker-choice-strategy.ts
+++ b/src/pools/selection-strategies/weighted-round-robin-worker-choice-strategy.ts
@@ -71,13 +71,17 @@ export class WeightedRoundRobinWorkerChoiceStrategy<
   }
 
   /** @inheritDoc */
-  public choose(): number | undefined {
+  public choose(workerNodeKeysSet?: ReadonlySet<number>): number | undefined {
     this.setPreviousWorkerNodeKey(this.nextWorkerNodeKey)
-    this.weightedRoundRobinNextWorkerNodeKey()
-    if (!this.isWorkerNodeReady(this.nextWorkerNodeKey!)) {
+    const chosenWorkerNodeKey =
+      this.weightedRoundRobinNextWorkerNodeKey(workerNodeKeysSet)
+    if (chosenWorkerNodeKey == null) {
       return undefined
     }
-    return this.checkWorkerNodeKey(this.nextWorkerNodeKey)
+    if (!this.isWorkerNodeEligible(chosenWorkerNodeKey, workerNodeKeysSet)) {
+      return undefined
+    }
+    return this.checkWorkerNodeKey(chosenWorkerNodeKey)
   }
 
   /** @inheritDoc */
@@ -102,20 +106,65 @@ export class WeightedRoundRobinWorkerChoiceStrategy<
     return true
   }
 
-  private weightedRoundRobinNextWorkerNodeKey(): number | undefined {
+  private weightedRoundRobinNextWorkerNodeKey(
+    workerNodeKeysSet?: ReadonlySet<number>,
+  ): number | undefined {
+    if (workerNodeKeysSet == null) {
+      const workerNodeKey = this.nextWorkerNodeKey ?? this.previousWorkerNodeKey
+      const workerWeight = this.opts!.weights![workerNodeKey]
+      if (this.workerNodeVirtualTaskExecutionTime < workerWeight) {
+        this.workerNodeVirtualTaskExecutionTime +=
+          this.getWorkerNodeTaskWaitTime(workerNodeKey) +
+          this.getWorkerNodeTaskRunTime(workerNodeKey)
+      } else {
+        this.nextWorkerNodeKey = this.getRoundRobinNextWorkerNodeKey()
+        this.workerNodeVirtualTaskExecutionTime = 0
+      }
+      return this.nextWorkerNodeKey
+    }
+    if (workerNodeKeysSet.size === 0) {
+      return undefined
+    }
+    if (workerNodeKeysSet.size === 1) {
+      const selectedWorkerNodeKey =
+        this.getSingleWorkerNodeKey(workerNodeKeysSet)
+      if (selectedWorkerNodeKey != null) {
+        this.nextWorkerNodeKey = selectedWorkerNodeKey
+        this.workerNodeVirtualTaskExecutionTime = 0
+      }
+      return selectedWorkerNodeKey
+    }
     const workerNodeKey = this.nextWorkerNodeKey ?? this.previousWorkerNodeKey
+    if (!workerNodeKeysSet.has(workerNodeKey)) {
+      this.nextWorkerNodeKey =
+        this.findEligibleWorkerNodeKey(workerNodeKeysSet)
+      this.workerNodeVirtualTaskExecutionTime = 0
+      return this.nextWorkerNodeKey
+    }
     const workerWeight = this.opts!.weights![workerNodeKey]
     if (this.workerNodeVirtualTaskExecutionTime < workerWeight) {
+      this.nextWorkerNodeKey = workerNodeKey
       this.workerNodeVirtualTaskExecutionTime +=
         this.getWorkerNodeTaskWaitTime(workerNodeKey) +
         this.getWorkerNodeTaskRunTime(workerNodeKey)
     } else {
       this.nextWorkerNodeKey =
-        this.nextWorkerNodeKey === this.pool.workerNodes.length - 1
-          ? 0
-          : workerNodeKey + 1
+        this.findEligibleWorkerNodeKey(workerNodeKeysSet)
       this.workerNodeVirtualTaskExecutionTime = 0
     }
     return this.nextWorkerNodeKey
+  }
+
+  private findEligibleWorkerNodeKey(
+    workerNodeKeysSet: ReadonlySet<number>,
+  ): number | undefined {
+    const workerNodesCount = this.pool.workerNodes.length
+    for (let i = 0; i < workerNodesCount; i++) {
+      this.nextWorkerNodeKey = this.getRoundRobinNextWorkerNodeKey()
+      if (workerNodeKeysSet.has(this.nextWorkerNodeKey)) {
+        return this.nextWorkerNodeKey
+      }
+    }
+    return undefined
   }
 }

--- a/src/pools/selection-strategies/worker-choice-strategies-context.ts
+++ b/src/pools/selection-strategies/worker-choice-strategies-context.ts
@@ -157,15 +157,18 @@ export class WorkerChoiceStrategiesContext<
    *
    * @param workerChoiceStrategy - The worker choice strategy algorithm to execute.
    * @defaultValue this.defaultWorkerChoiceStrategy
+   * @param workerNodeKeysSet - The worker node keys set to choose from.
    * @returns The key of the worker node.
    * @throws {Error} If after computed retries the worker node key is null or undefined.
    */
   public execute(
     workerChoiceStrategy: WorkerChoiceStrategy = this
       .defaultWorkerChoiceStrategy,
+    workerNodeKeysSet?: ReadonlySet<number>,
   ): number {
     return this.executeStrategy(
       this.workerChoiceStrategies.get(workerChoiceStrategy)!,
+      workerNodeKeysSet,
     )
   }
 
@@ -173,15 +176,20 @@ export class WorkerChoiceStrategiesContext<
    * Executes the given worker choice strategy.
    *
    * @param workerChoiceStrategy - The worker choice strategy.
+   * @param workerNodeKeysSet - The worker node keys set to choose from.
    * @returns The key of the worker node.
    * @throws {Error} If after computed retries the worker node key is null or undefined.
    */
-  private executeStrategy(workerChoiceStrategy: IWorkerChoiceStrategy): number {
-    let workerNodeKey: number | undefined = workerChoiceStrategy.choose()
+  private executeStrategy(
+    workerChoiceStrategy: IWorkerChoiceStrategy,
+    workerNodeKeysSet?: ReadonlySet<number>,
+  ): number {
+    let workerNodeKey: number | undefined =
+      workerChoiceStrategy.choose(workerNodeKeysSet)
     let retriesCount = 0
     while (workerNodeKey == null && retriesCount < this.retries) {
       retriesCount++
-      workerNodeKey = workerChoiceStrategy.choose()
+      workerNodeKey = workerChoiceStrategy.choose(workerNodeKeysSet)
     }
     workerChoiceStrategy.retriesCount = retriesCount
     if (workerNodeKey == null) {

--- a/src/pools/selection-strategies/worker-choice-strategies-context.ts
+++ b/src/pools/selection-strategies/worker-choice-strategies-context.ts
@@ -184,8 +184,9 @@ export class WorkerChoiceStrategiesContext<
     workerChoiceStrategy: IWorkerChoiceStrategy,
     workerNodeKeysSet?: ReadonlySet<number>,
   ): number {
-    let workerNodeKey: number | undefined =
-      workerChoiceStrategy.choose(workerNodeKeysSet)
+    let workerNodeKey: number | undefined = workerChoiceStrategy.choose(
+      workerNodeKeysSet,
+    )
     let retriesCount = 0
     while (workerNodeKey == null && retriesCount < this.retries) {
       retriesCount++

--- a/src/pools/utils.ts
+++ b/src/pools/utils.ts
@@ -124,6 +124,48 @@ export const checkValidWorkerChoiceStrategy = (
   }
 }
 
+export const checkValidWorkerNodeKeys = (
+  workerNodeKeys: null | number[] | undefined,
+  maxPoolSize?: number,
+): void => {
+  if (workerNodeKeys != null && !Array.isArray(workerNodeKeys)) {
+    throw new TypeError('Invalid worker node keys: must be an array')
+  }
+  if (workerNodeKeys?.length === 0) {
+    throw new RangeError('Invalid worker node keys: must not be an empty array')
+  }
+  if (workerNodeKeys != null) {
+    for (const workerNodeKey of workerNodeKeys) {
+      if (!Number.isSafeInteger(workerNodeKey) || workerNodeKey < 0) {
+        throw new TypeError(
+          `Invalid worker node key '${workerNodeKey.toString()}': must be a non-negative safe integer`,
+        )
+      }
+    }
+  }
+  if (
+    workerNodeKeys != null &&
+    new Set(workerNodeKeys).size !== workerNodeKeys.length
+  ) {
+    throw new TypeError('Invalid worker node keys: must not contain duplicates')
+  }
+  if (maxPoolSize != null && workerNodeKeys != null) {
+    if (workerNodeKeys.length > maxPoolSize) {
+      throw new RangeError(
+        'Cannot add a task function with more worker node keys than the maximum number of workers in the pool',
+      )
+    }
+    const invalidWorkerNodeKeys = workerNodeKeys.filter(
+      (workerNodeKey) => workerNodeKey >= maxPoolSize,
+    )
+    if (invalidWorkerNodeKeys.length > 0) {
+      throw new RangeError(
+        `Cannot add a task function with invalid worker node keys: ${invalidWorkerNodeKeys.toString()}. Valid keys are: 0..${(maxPoolSize - 1).toString()}`,
+      )
+    }
+  }
+}
+
 export const checkValidTasksQueueOptions = (
   tasksQueueOptions: TasksQueueOptions | undefined,
 ): void => {

--- a/src/pools/utils.ts
+++ b/src/pools/utils.ts
@@ -160,7 +160,9 @@ export const checkValidWorkerNodeKeys = (
     )
     if (invalidWorkerNodeKeys.length > 0) {
       throw new RangeError(
-        `Cannot add a task function with invalid worker node keys: ${invalidWorkerNodeKeys.toString()}. Valid keys are: 0..${(maxPoolSize - 1).toString()}`,
+        `Cannot add a task function with invalid worker node keys: ${invalidWorkerNodeKeys.toString()}. Valid keys are: 0..${
+          (maxPoolSize - 1).toString()
+        }`,
       )
     }
   }

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -91,7 +91,10 @@ export interface TaskFunctionProperties {
    */
   readonly strategy?: WorkerChoiceStrategy
   /**
-   * Task function worker node keys on which to run.
+   * Task function worker node keys affinity.
+   * Restricts task execution to specified worker nodes by their indices.
+   * Must contain valid indices within [0, pool max size - 1].
+   * If undefined, task can execute on any worker node.
    */
   readonly workerNodeKeys?: number[]
 }

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -90,6 +90,10 @@ export interface TaskFunctionProperties {
    * Task function worker choice strategy.
    */
   readonly strategy?: WorkerChoiceStrategy
+  /**
+   * Task function worker node keys on which to run.
+   */
+  readonly workerNodeKeys?: number[]
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -232,6 +232,9 @@ export const buildTaskFunctionProperties = <Data, Response>(
     ...(taskFunctionObject?.strategy != null && {
       strategy: taskFunctionObject.strategy,
     }),
+    ...(taskFunctionObject?.workerNodeKeys != null && {
+      workerNodeKeys: taskFunctionObject.workerNodeKeys,
+    }),
   }
 }
 

--- a/src/worker/abstract-worker.ts
+++ b/src/worker/abstract-worker.ts
@@ -404,6 +404,9 @@ export abstract class AbstractWorker<
           ...(taskFunctionProperties.strategy != null && {
             strategy: taskFunctionProperties.strategy,
           }),
+          ...(taskFunctionProperties.workerNodeKeys != null && {
+            workerNodeKeys: taskFunctionProperties.workerNodeKeys,
+          }),
         })
         break
       case 'remove':

--- a/src/worker/task-functions.ts
+++ b/src/worker/task-functions.ts
@@ -57,6 +57,15 @@ export interface TaskFunctionObject<Data = unknown, Response = unknown> {
    * Task function worker choice strategy.
    */
   strategy?: WorkerChoiceStrategy
+  /**
+   * Task function worker node keys affinity.
+   * Restricts task execution to specified worker nodes by their indices.
+   * Must contain valid indices within [0, pool max size - 1].
+   * If undefined, task can execute on any worker node.
+   * @remarks `null` is not accepted here. Use `null` only via
+   * {@link TaskFunctionProperties.workerNodeKeys} to clear affinity at runtime.
+   */
+  workerNodeKeys?: number[]
 }
 
 /**

--- a/src/worker/task-functions.ts
+++ b/src/worker/task-functions.ts
@@ -62,8 +62,6 @@ export interface TaskFunctionObject<Data = unknown, Response = unknown> {
    * Restricts task execution to specified worker nodes by their indices.
    * Must contain valid indices within [0, pool max size - 1].
    * If undefined, task can execute on any worker node.
-   * @remarks `null` is not accepted here. Use `null` only via
-   * {@link TaskFunctionProperties.workerNodeKeys} to clear affinity at runtime.
    */
   workerNodeKeys?: number[]
 }

--- a/src/worker/utils.ts
+++ b/src/worker/utils.ts
@@ -1,6 +1,7 @@
 import {
   checkValidPriority,
   checkValidWorkerChoiceStrategy,
+  checkValidWorkerNodeKeys,
 } from '../pools/utils.ts'
 import { isPlainObject } from '../utils.ts'
 import type { TaskFunctionObject } from './task-functions.ts'
@@ -48,6 +49,7 @@ export const checkValidTaskFunctionObjectEntry = <
   }
   checkValidPriority(fnObj.priority)
   checkValidWorkerChoiceStrategy(fnObj.strategy)
+  checkValidWorkerNodeKeys(fnObj.workerNodeKeys)
 }
 
 export const checkTaskFunctionName = (name: string): void => {

--- a/tests/pools/abstract-pool.test.mjs
+++ b/tests/pools/abstract-pool.test.mjs
@@ -1670,6 +1670,181 @@ describe({
       await dynamicThreadPool.destroy()
     })
 
+    it('Verify that addTaskFunction() with workerNodeKeys is working', async () => {
+      const dynamicThreadPool = new DynamicThreadPool(
+        Math.floor(numberOfWorkers / 2),
+        numberOfWorkers,
+        new URL('./../worker-files/thread/testWorker.mjs', import.meta.url),
+      )
+      await waitPoolEvents(dynamicThreadPool, PoolEvents.ready, 1)
+      const poolWorkerNodeKeys = [...dynamicThreadPool.workerNodes.keys()]
+
+      // Test with valid workerNodeKeys
+      const echoTaskFunction = (data) => {
+        return data
+      }
+      await expect(
+        dynamicThreadPool.addTaskFunction('affinityEcho', {
+          taskFunction: echoTaskFunction,
+          workerNodeKeys: [poolWorkerNodeKeys[0]],
+        }),
+      ).resolves.toBe(true)
+      expect(dynamicThreadPool.taskFunctions.get('affinityEcho')).toStrictEqual({
+        taskFunction: echoTaskFunction,
+        workerNodeKeys: [poolWorkerNodeKeys[0]],
+      })
+
+      // Test with invalid workerNodeKeys (out of range)
+      await expect(
+        dynamicThreadPool.addTaskFunction('invalidKeys', {
+          taskFunction: () => {},
+          workerNodeKeys: [999],
+        }),
+      ).rejects.toThrow(
+        new RangeError(
+          'Cannot add a task function with invalid worker node keys: 999. Valid keys are: 0..1',
+        ),
+      )
+
+      // Test with empty array workerNodeKeys
+      await expect(
+        dynamicThreadPool.addTaskFunction('emptyKeys', {
+          taskFunction: () => {},
+          workerNodeKeys: [],
+        }),
+      ).rejects.toThrow(
+        new RangeError('Invalid worker node keys: must not be an empty array'),
+      )
+
+      // Test exceeding max workers
+      const tooManyKeys = Array.from({ length: numberOfWorkers + 1 }, (_, i) => i)
+      await expect(
+        dynamicThreadPool.addTaskFunction('tooManyKeys', {
+          taskFunction: () => {},
+          workerNodeKeys: tooManyKeys,
+        }),
+      ).rejects.toThrow(
+        new RangeError(
+          'Cannot add a task function with more worker node keys than the maximum number of workers in the pool',
+        ),
+      )
+
+      // Test with duplicate workerNodeKeys
+      await expect(
+        dynamicThreadPool.addTaskFunction('duplicateKeys', {
+          taskFunction: () => {},
+          workerNodeKeys: [poolWorkerNodeKeys[0], poolWorkerNodeKeys[0]],
+        }),
+      ).rejects.toThrow(
+        new TypeError('Invalid worker node keys: must not contain duplicates'),
+      )
+
+      // Test with non-integer values
+      await expect(
+        dynamicThreadPool.addTaskFunction('nonIntegerKeys', {
+          taskFunction: () => {},
+          workerNodeKeys: [1.5],
+        }),
+      ).rejects.toThrow(
+        new TypeError(
+          "Invalid worker node key '1.5': must be a non-negative safe integer",
+        ),
+      )
+
+      // Test with negative values
+      await expect(
+        dynamicThreadPool.addTaskFunction('negativeKeys', {
+          taskFunction: () => {},
+          workerNodeKeys: [-1],
+        }),
+      ).rejects.toThrow(
+        new TypeError(
+          "Invalid worker node key '-1': must be a non-negative safe integer",
+        ),
+      )
+
+      await dynamicThreadPool.destroy()
+    })
+
+    it('Verify that execute() respects workerNodeKeys affinity', async () => {
+      const dynamicThreadPool = new DynamicThreadPool(
+        Math.floor(numberOfWorkers / 2),
+        numberOfWorkers,
+        new URL('./../worker-files/thread/testWorker.mjs', import.meta.url),
+      )
+      await waitPoolEvents(dynamicThreadPool, PoolEvents.ready, 1)
+      const poolWorkerNodeKeys = [...dynamicThreadPool.workerNodes.keys()]
+
+      // Add task function with affinity to first worker only
+      const affinityTaskFunction = (data) => {
+        return data
+      }
+      await dynamicThreadPool.addTaskFunction('affinityTask', {
+        taskFunction: affinityTaskFunction,
+        workerNodeKeys: [poolWorkerNodeKeys[0]],
+      })
+
+      // Reset task counts to track new executions
+      for (const workerNode of dynamicThreadPool.workerNodes) {
+        workerNode.usage.tasks.executed = 0
+      }
+
+      // Execute multiple tasks with affinity
+      const numTasks = 5
+      const tasks = []
+      for (let i = 0; i < numTasks; i++) {
+        tasks.push(dynamicThreadPool.execute({ test: i }, 'affinityTask'))
+      }
+      await Promise.all(tasks)
+
+      // Verify that only the affinity worker received the tasks
+      const affinityWorkerNode =
+        dynamicThreadPool.workerNodes[poolWorkerNodeKeys[0]]
+      expect(affinityWorkerNode.usage.tasks.executed).toBe(numTasks)
+
+      // Other workers should have 0 tasks from affinityTask
+      for (let i = 0; i < dynamicThreadPool.workerNodes.length; i++) {
+        if (i !== poolWorkerNodeKeys[0]) {
+          expect(dynamicThreadPool.workerNodes[i].usage.tasks.executed).toBe(0)
+        }
+      }
+
+      await dynamicThreadPool.destroy()
+    })
+
+    it('Verify that execute() creates dynamic workers for workerNodeKeys affinity', async () => {
+      const dynamicThreadPool = new DynamicThreadPool(
+        1,
+        4,
+        new URL('./../worker-files/thread/testWorker.mjs', import.meta.url),
+      )
+      await waitPoolEvents(dynamicThreadPool, PoolEvents.ready, 1)
+      expect(dynamicThreadPool.workerNodes.length).toBe(1)
+
+      await dynamicThreadPool.addTaskFunction('affinityBeyondMin', {
+        taskFunction: (data) => data,
+        workerNodeKeys: [2, 3],
+      })
+
+      for (const workerNode of dynamicThreadPool.workerNodes) {
+        workerNode.usage.tasks.executed = 0
+      }
+
+      const tasks = []
+      for (let i = 0; i < 4; i++) {
+        tasks.push(dynamicThreadPool.execute({ test: i }, 'affinityBeyondMin'))
+      }
+      await Promise.all(tasks)
+
+      expect(dynamicThreadPool.workerNodes.length).toBeGreaterThanOrEqual(4)
+      const executedOnAffinity =
+        dynamicThreadPool.workerNodes[2].usage.tasks.executed +
+        dynamicThreadPool.workerNodes[3].usage.tasks.executed
+      expect(executedOnAffinity).toBe(4)
+
+      await dynamicThreadPool.destroy()
+    })
+
     it('Verify that removeTaskFunction() is working', async () => {
       const dynamicThreadPool = new DynamicThreadPool(
         Math.floor(numberOfWorkers / 2),
@@ -1739,8 +1914,8 @@ describe({
       expect(dynamicThreadPool.listTaskFunctionsProperties()).toStrictEqual([
         { name: DEFAULT_TASK_NAME },
         { name: 'jsonIntegerSerialization' },
-        { name: 'factorial' },
-        { name: 'fibonacci' },
+        { name: 'factorial', priority: 1, workerNodeKeys: [0] },
+        { name: 'fibonacci', priority: 2, workerNodeKeys: [0, 1] },
       ])
       await dynamicThreadPool.destroy()
       const fixedClusterPool = new FixedThreadPool(
@@ -1754,8 +1929,8 @@ describe({
       expect(fixedClusterPool.listTaskFunctionsProperties()).toStrictEqual([
         { name: DEFAULT_TASK_NAME },
         { name: 'jsonIntegerSerialization' },
-        { name: 'factorial' },
-        { name: 'fibonacci' },
+        { name: 'factorial', priority: 1, workerNodeKeys: [0] },
+        { name: 'fibonacci', priority: 2, workerNodeKeys: [0, 1] },
       ])
       await fixedClusterPool.destroy()
     })
@@ -1802,26 +1977,26 @@ describe({
       expect(dynamicThreadPool.listTaskFunctionsProperties()).toStrictEqual([
         { name: DEFAULT_TASK_NAME },
         { name: 'jsonIntegerSerialization' },
-        { name: 'factorial' },
-        { name: 'fibonacci' },
+        { name: 'factorial', priority: 1, workerNodeKeys: [0] },
+        { name: 'fibonacci', priority: 2, workerNodeKeys: [0, 1] },
       ])
       await expect(
         dynamicThreadPool.setDefaultTaskFunction('factorial'),
       ).resolves.toBe(true)
       expect(dynamicThreadPool.listTaskFunctionsProperties()).toStrictEqual([
-        { name: DEFAULT_TASK_NAME },
-        { name: 'factorial' },
+        { name: DEFAULT_TASK_NAME, priority: 1, workerNodeKeys: [0] },
+        { name: 'factorial', priority: 1, workerNodeKeys: [0] },
         { name: 'jsonIntegerSerialization' },
-        { name: 'fibonacci' },
+        { name: 'fibonacci', priority: 2, workerNodeKeys: [0, 1] },
       ])
       await expect(
         dynamicThreadPool.setDefaultTaskFunction('fibonacci'),
       ).resolves.toBe(true)
       expect(dynamicThreadPool.listTaskFunctionsProperties()).toStrictEqual([
-        { name: DEFAULT_TASK_NAME },
-        { name: 'fibonacci' },
+        { name: DEFAULT_TASK_NAME, priority: 2, workerNodeKeys: [0, 1] },
+        { name: 'fibonacci', priority: 2, workerNodeKeys: [0, 1] },
         { name: 'jsonIntegerSerialization' },
-        { name: 'factorial' },
+        { name: 'factorial', priority: 1, workerNodeKeys: [0] },
       ])
       await dynamicThreadPool.destroy()
     })
@@ -1847,15 +2022,18 @@ describe({
       expect(pool.info.executingTasks).toBe(0)
       expect(pool.info.executedTasks).toBe(4)
       for (const workerNode of pool.workerNodes) {
+        if (workerNode.info.taskFunctionsProperties == null) {
+          continue
+        }
         expect(workerNode.info.taskFunctionsProperties).toStrictEqual([
           { name: DEFAULT_TASK_NAME },
           { name: 'jsonIntegerSerialization' },
-          { name: 'factorial' },
-          { name: 'fibonacci' },
+          { name: 'factorial', priority: 1, workerNodeKeys: [0] },
+          { name: 'fibonacci', priority: 2, workerNodeKeys: [0, 1] },
         ])
         expect(workerNode.taskFunctionsUsage.size).toBe(3)
         expect(workerNode.usage.tasks.executed).toBeGreaterThan(0)
-        expect(workerNode.tasksQueue.enablePriority).toBe(false)
+        expect(workerNode.tasksQueue.enablePriority).toBe(true)
         for (
           const taskFunctionProperties of pool.listTaskFunctionsProperties()
         ) {
@@ -2018,7 +2196,7 @@ describe({
       )
       const data = { n: 10 }
       const result0 = await pool.execute(data)
-      expect(result0).toStrictEqual({ ok: 1 })
+      expect(result0).toBe(3628800n)
       const result1 = await pool.execute(data, 'jsonIntegerSerialization')
       expect(result1).toStrictEqual({ ok: 1 })
       const result2 = await pool.execute(data, 'factorial')
@@ -2028,11 +2206,14 @@ describe({
       expect(pool.info.executingTasks).toBe(0)
       expect(pool.info.executedTasks).toBe(4)
       for (const workerNode of pool.workerNodes) {
+        if (workerNode.info.taskFunctionsProperties == null) {
+          continue
+        }
         expect(workerNode.info.taskFunctionsProperties).toStrictEqual([
-          { name: DEFAULT_TASK_NAME },
+          { name: DEFAULT_TASK_NAME, workerNodeKeys: [0] },
+          { name: 'factorial', workerNodeKeys: [0] },
+          { name: 'fibonacci', priority: -5, workerNodeKeys: [0, 1] },
           { name: 'jsonIntegerSerialization' },
-          { name: 'factorial' },
-          { name: 'fibonacci', priority: -5 },
         ])
         expect(workerNode.taskFunctionsUsage.size).toBe(3)
         expect(workerNode.usage.tasks.executed).toBeGreaterThan(0)

--- a/tests/pools/abstract-pool.test.mjs
+++ b/tests/pools/abstract-pool.test.mjs
@@ -1689,10 +1689,12 @@ describe({
           workerNodeKeys: [poolWorkerNodeKeys[0]],
         }),
       ).resolves.toBe(true)
-      expect(dynamicThreadPool.taskFunctions.get('affinityEcho')).toStrictEqual({
-        taskFunction: echoTaskFunction,
-        workerNodeKeys: [poolWorkerNodeKeys[0]],
-      })
+      expect(dynamicThreadPool.taskFunctions.get('affinityEcho')).toStrictEqual(
+        {
+          taskFunction: echoTaskFunction,
+          workerNodeKeys: [poolWorkerNodeKeys[0]],
+        },
+      )
 
       // Test with invalid workerNodeKeys (out of range)
       await expect(
@@ -1717,7 +1719,10 @@ describe({
       )
 
       // Test exceeding max workers
-      const tooManyKeys = Array.from({ length: numberOfWorkers + 1 }, (_, i) => i)
+      const tooManyKeys = Array.from(
+        { length: numberOfWorkers + 1 },
+        (_, i) => i,
+      )
       await expect(
         dynamicThreadPool.addTaskFunction('tooManyKeys', {
           taskFunction: () => {},

--- a/tests/pools/selection-strategies/weighted-round-robin-worker-choice-strategy.test.mjs
+++ b/tests/pools/selection-strategies/weighted-round-robin-worker-choice-strategy.test.mjs
@@ -2,11 +2,16 @@ import { randomInt } from 'node:crypto'
 import { expect } from '@std/expect'
 import { after, before, describe, it } from '@std/testing/bdd'
 import { FixedThreadPool } from '../../../src/mod.ts'
+import { FairShareWorkerChoiceStrategy } from '../../../src/pools/selection-strategies/fair-share-worker-choice-strategy.ts'
 import { InterleavedWeightedRoundRobinWorkerChoiceStrategy } from '../../../src/pools/selection-strategies/interleaved-weighted-round-robin-worker-choice-strategy.ts'
+import { LeastBusyWorkerChoiceStrategy } from '../../../src/pools/selection-strategies/least-busy-worker-choice-strategy.ts'
+// LeastEluWorkerChoiceStrategy is not available in web workers (no ELU metrics)
+// import { LeastEluWorkerChoiceStrategy } from '../../../src/pools/selection-strategies/least-elu-worker-choice-strategy.ts'
+import { LeastUsedWorkerChoiceStrategy } from '../../../src/pools/selection-strategies/least-used-worker-choice-strategy.ts'
+import { RoundRobinWorkerChoiceStrategy } from '../../../src/pools/selection-strategies/round-robin-worker-choice-strategy.ts'
 import { WeightedRoundRobinWorkerChoiceStrategy } from '../../../src/pools/selection-strategies/weighted-round-robin-worker-choice-strategy.ts'
 
-describe('Weighted round robin strategy worker choice strategy test suite', () => {
-  // const min = 1
+describe('Weighted round robin worker choice strategy test suite', () => {
   const max = 3
   let pool
 
@@ -53,5 +58,121 @@ describe('Weighted round robin strategy worker choice strategy test suite', () =
     expect(strategy.roundId).toBe(0)
     expect(strategy.workerNodeId).toBe(0)
     expect(strategy.workerNodeVirtualTaskExecutionTime).toBe(0)
+  })
+
+  it('Verify that RoundRobin choose() with empty workerNodeKeysSet returns undefined', () => {
+    const strategy = new RoundRobinWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set())).toBe(undefined)
+  })
+
+  it('Verify that RoundRobin choose() with single workerNodeKey returns that key if ready', () => {
+    const strategy = new RoundRobinWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set([0]))).toBe(0)
+  })
+
+  it('Verify that RoundRobin choose() respects workerNodeKeys affinity', () => {
+    const strategy = new RoundRobinWorkerChoiceStrategy(pool)
+    const workerNodeKeysSet = new Set([1, 2])
+    expect(workerNodeKeysSet.has(strategy.choose(workerNodeKeysSet))).toBe(true)
+  })
+
+  it('Verify that LeastUsed choose() with empty workerNodeKeysSet returns undefined', () => {
+    const strategy = new LeastUsedWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set())).toBe(undefined)
+  })
+
+  it('Verify that LeastUsed choose() with single workerNodeKey returns that key if ready', () => {
+    const strategy = new LeastUsedWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set([0]))).toBe(0)
+  })
+
+  it('Verify that LeastUsed choose() respects workerNodeKeys affinity', () => {
+    const strategy = new LeastUsedWorkerChoiceStrategy(pool)
+    const workerNodeKeysSet = new Set([1, 2])
+    expect(workerNodeKeysSet.has(strategy.choose(workerNodeKeysSet))).toBe(true)
+  })
+
+  it('Verify that LeastBusy choose() with empty workerNodeKeysSet returns undefined', () => {
+    const strategy = new LeastBusyWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set())).toBe(undefined)
+  })
+
+  it('Verify that LeastBusy choose() with single workerNodeKey returns that key if ready', () => {
+    const strategy = new LeastBusyWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set([0]))).toBe(0)
+  })
+
+  it('Verify that LeastBusy choose() respects workerNodeKeys affinity', () => {
+    const strategy = new LeastBusyWorkerChoiceStrategy(pool)
+    const workerNodeKeysSet = new Set([1, 2])
+    expect(workerNodeKeysSet.has(strategy.choose(workerNodeKeysSet))).toBe(true)
+  })
+
+  // LeastElu tests are commented out because LeastEluWorkerChoiceStrategy
+  // is not available in web workers (no ELU metrics support)
+  // it('Verify that LeastElu choose() with empty workerNodeKeysSet returns undefined', () => {
+  //   const strategy = new LeastEluWorkerChoiceStrategy(pool)
+  //   expect(strategy.choose(new Set())).toBe(undefined)
+  // })
+
+  // it('Verify that LeastElu choose() with single workerNodeKey returns that key if ready', () => {
+  //   const strategy = new LeastEluWorkerChoiceStrategy(pool)
+  //   expect(strategy.choose(new Set([0]))).toBe(0)
+  // })
+
+  // it('Verify that LeastElu choose() respects workerNodeKeys affinity', () => {
+  //   const strategy = new LeastEluWorkerChoiceStrategy(pool)
+  //   const workerNodeKeysSet = new Set([1, 2])
+  //   expect(workerNodeKeysSet.has(strategy.choose(workerNodeKeysSet))).toBe(true)
+  // })
+
+  it('Verify that FairShare choose() with empty workerNodeKeysSet returns undefined', () => {
+    const strategy = new FairShareWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set())).toBe(undefined)
+  })
+
+  it('Verify that FairShare choose() with single workerNodeKey returns that key if ready', () => {
+    const strategy = new FairShareWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set([0]))).toBe(0)
+  })
+
+  it('Verify that FairShare choose() respects workerNodeKeys affinity', () => {
+    const strategy = new FairShareWorkerChoiceStrategy(pool)
+    const workerNodeKeysSet = new Set([1, 2])
+    expect(workerNodeKeysSet.has(strategy.choose(workerNodeKeysSet))).toBe(true)
+  })
+
+  it('Verify that WeightedRoundRobin choose() with empty workerNodeKeysSet returns undefined', () => {
+    const strategy = new WeightedRoundRobinWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set())).toBe(undefined)
+  })
+
+  it('Verify that WeightedRoundRobin choose() with single workerNodeKey returns that key if ready', () => {
+    const strategy = new WeightedRoundRobinWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set([0]))).toBe(0)
+  })
+
+  it('Verify that WeightedRoundRobin choose() respects workerNodeKeys affinity', () => {
+    const strategy = new WeightedRoundRobinWorkerChoiceStrategy(pool)
+    const workerNodeKeysSet = new Set([1, 2])
+    const result = strategy.choose(workerNodeKeysSet)
+    expect(result === undefined || workerNodeKeysSet.has(result)).toBe(true)
+  })
+
+  it('Verify that InterleavedWeightedRoundRobin choose() with empty workerNodeKeysSet returns undefined', () => {
+    const strategy = new InterleavedWeightedRoundRobinWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set())).toBe(undefined)
+  })
+
+  it('Verify that InterleavedWeightedRoundRobin choose() with single workerNodeKey returns that key if ready', () => {
+    const strategy = new InterleavedWeightedRoundRobinWorkerChoiceStrategy(pool)
+    expect(strategy.choose(new Set([0]))).toBe(0)
+  })
+
+  it('Verify that InterleavedWeightedRoundRobin choose() respects workerNodeKeys affinity', () => {
+    const strategy = new InterleavedWeightedRoundRobinWorkerChoiceStrategy(pool)
+    const workerNodeKeysSet = new Set([1, 2])
+    const result = strategy.choose(workerNodeKeysSet)
+    expect(result === undefined || workerNodeKeysSet.has(result)).toBe(true)
   })
 })

--- a/tests/worker-files/thread/testMultipleTaskFunctionsWorker.mjs
+++ b/tests/worker-files/thread/testMultipleTaskFunctionsWorker.mjs
@@ -8,8 +8,16 @@ import {
 export default new ThreadWorker(
   {
     jsonIntegerSerialization: (data) => jsonIntegerSerialization(data.n),
-    factorial: (data) => factorial(data.n),
-    fibonacci: (data) => fibonacci(data.n),
+    factorial: {
+      priority: 1,
+      taskFunction: (data) => factorial(data.n),
+      workerNodeKeys: [0],
+    },
+    fibonacci: {
+      priority: 2,
+      taskFunction: (data) => fibonacci(data.n),
+      workerNodeKeys: [0, 1],
+    },
   },
   {
     killBehavior: KillBehaviors.HARD,

--- a/tests/worker-files/thread/testTaskFunctionObjectsWorker.mjs
+++ b/tests/worker-files/thread/testTaskFunctionObjectsWorker.mjs
@@ -7,11 +7,18 @@ import {
 
 export default new ThreadWorker(
   {
+    factorial: {
+      taskFunction: (data) => factorial(data.n),
+      workerNodeKeys: [0],
+    },
+    fibonacci: {
+      priority: -5,
+      taskFunction: (data) => fibonacci(data.n),
+      workerNodeKeys: [0, 1],
+    },
     jsonIntegerSerialization: {
       taskFunction: (data) => jsonIntegerSerialization(data.n),
     },
-    factorial: { taskFunction: (data) => factorial(data.n) },
-    fibonacci: { taskFunction: (data) => fibonacci(data.n), priority: -5 },
   },
   {
     killBehavior: KillBehaviors.HARD,


### PR DESCRIPTION
## Summary

- Port task function worker node affinity from [poolifier/poolifier#2269](https://github.com/poolifier/poolifier/pull/2269)
- Allow restricting task execution to specific worker nodes by their indices via `workerNodeKeys` property on task function objects
- Support dynamic worker creation for affinity keys exceeding current pool size

## Changes

**Core** (`src/pools/`): `workerNodeKeys` validation, `workerNodeKeysSet` construction and passing through strategy context, dynamic worker provisioning for affinity keys

**Strategies** (`src/pools/selection-strategies/`): All 7 strategies updated to accept `workerNodeKeysSet` parameter and filter eligible workers accordingly, with early-return optimizations for empty/single-key sets

**Worker** (`src/worker/`): `workerNodeKeys` propagation in task function registration, listing, and CRUD operations

**Types**: `TaskFunctionProperties.workerNodeKeys` (nullable for runtime clearing), `TaskFunctionObject.workerNodeKeys`, `MessageValue.taskFunctionProperties`

**Tests**: 25 files changed, comprehensive coverage for affinity execution, dynamic worker creation, strategy filtering, and validation