### PR TITLE
revert: remove scheduler overhead tolerance

### DIFF
--- a/tests/pools/abstract-pool.test.mjs
+++ b/tests/pools/abstract-pool.test.mjs
@@ -1590,14 +1590,9 @@ describe({
       await pool.destroy()
       const elapsedTime = performance.now() - startTime
       expect(tasksFinished).toBe(0)
-      // Worker kill message response timeout is 1000ms.
-      // Allow a small scheduler overhead margin on busy CI hosts.
-      const schedulerOverheadMargin = 100
+      // Worker kill message response timeout is 1000ms
       expect(elapsedTime).toBeLessThanOrEqual(
-        tasksFinishedTimeout +
-          1000 * tasksFinished +
-          1000 +
-          schedulerOverheadMargin,
+        tasksFinishedTimeout + 1000 * tasksFinished + 1000,
       )
     })
 


### PR DESCRIPTION
Reverts the Hermes-introduced test timing tolerance from PR #152, restoring the previous assertion exactly.