### PR TITLE
Fix Bun .d.ts bundle broken by TypeScript 7 resolution

### DIFF
--- a/build/bun.lock
+++ b/build/bun.lock
@@ -1,0 +1,59 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@poolifier/poolifier-web-worker-build",
+      "dependencies": {
+        "bun-plugin-dts": "^0.4.0",
+        "dts-bundle-generator": "^9.5.1",
+        "typescript": "^5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "bun-plugin-dts": ["bun-plugin-dts@0.4.0", "", { "dependencies": { "common-path-prefix": "^3.0.0", "dts-bundle-generator": "^9.5.1", "get-tsconfig": "^4.13.6" } }, "sha512-g/pHy9SuhnUw+E+bHnJvADOnnZlEIci3nvZY8EuQEMwkpC4V4Kmoa2nG9nfda4jmjj+0POlCRCjdqXrL9gjYtA=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "common-path-prefix": ["common-path-prefix@3.0.0", "", {}, "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="],
+
+    "dts-bundle-generator": ["dts-bundle-generator@9.5.1", "", { "dependencies": { "typescript": ">=5.0.2", "yargs": "^17.6.0" }, "bin": { "dts-bundle-generator": "dist/bin/dts-bundle-generator.js" } }, "sha512-DxpJOb2FNnEyOzMkG11sxO2dmxPjthoVWxfKqWYJ/bI/rT1rvTMktF5EKjAYrRZu6Z6t3NhOUZ0sZ5ZXevOfbA=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+  }
+}

--- a/build/package.json
+++ b/build/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@poolifier/poolifier-web-worker-build",
   "version": "0.0.0",
-  "description": "Build-only dependencies for poolifier-web-worker (Bun bundle + .d.ts generation). Not published.",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@poolifier/poolifier-web-worker-build",
   "version": "0.0.0",
+  "description": "Build-only dependencies",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/build/package.json
+++ b/build/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@poolifier/poolifier-web-worker-build",
+  "version": "0.0.0",
+  "description": "Build-only dependencies for poolifier-web-worker (Bun bundle + .d.ts generation). Not published.",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "bun-plugin-dts": "^0.4.0",
+    "dts-bundle-generator": "^9.5.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/bundle.ts
+++ b/bundle.ts
@@ -3,9 +3,6 @@ import { baseBuildDir } from './build/config.ts'
 Deno.copyFileSync('LICENSE', `${baseBuildDir}/LICENSE`)
 Deno.copyFileSync('README.md', `${baseBuildDir}/README.md`)
 
-// Install build-only dependencies with TypeScript pinned in ./build/package.json:
-// dts-bundle-generator needs the legacy TS JS API (ts.sys), absent from TS 7 which
-// Bun would otherwise resolve from its ">=5.0.2" range.
 console.time('Bun install time')
 const bunInstall = new Deno.Command('bun', {
   args: ['install', '--cwd', './build', '--no-progress', '--no-summary'],

--- a/bundle.ts
+++ b/bundle.ts
@@ -11,7 +11,7 @@ Deno.copyFileSync('README.md', `${baseBuildDir}/README.md`)
 // plugin, in particular ts.sys), breaking the .d.ts bundle step.
 console.time('Bun install time')
 const bunInstall = new Deno.Command('bun', {
-  args: ['install', '--cwd', './build', '--silent'],
+  args: ['install', '--cwd', './build', '--no-progress', '--no-summary'],
 })
 const bunInstallCommandOutput = bunInstall.outputSync()
 if (bunInstallCommandOutput.success === false) {

--- a/bundle.ts
+++ b/bundle.ts
@@ -3,6 +3,24 @@ import { baseBuildDir } from './build/config.ts'
 Deno.copyFileSync('LICENSE', `${baseBuildDir}/LICENSE`)
 Deno.copyFileSync('README.md', `${baseBuildDir}/README.md`)
 
+// Install build-only dependencies (bun-plugin-dts and its peers) with the
+// TypeScript version pinned in ./build/package.json. This is required because
+// dts-bundle-generator@9.5.1 declares typescript: ">=5.0.2" and, without a
+// local package.json, Bun resolves that range to the TypeScript 7 native
+// rewrite (which does not expose the legacy JS compiler API used by the
+// plugin, in particular ts.sys), breaking the .d.ts bundle step.
+console.time('Bun install time')
+const bunInstall = new Deno.Command('bun', {
+  args: ['install', '--cwd', './build', '--silent'],
+})
+const bunInstallCommandOutput = bunInstall.outputSync()
+if (bunInstallCommandOutput.success === false) {
+  const errMsg = new TextDecoder().decode(bunInstallCommandOutput.stderr)
+  console.error(errMsg)
+  throw new Error(`Bun install failed: ${errMsg}`)
+}
+console.timeEnd('Bun install time')
+
 console.time('Browser build time')
 const browserBuild = new Deno.Command('bun', {
   args: ['run', './build/browser-build.ts'],

--- a/bundle.ts
+++ b/bundle.ts
@@ -3,12 +3,9 @@ import { baseBuildDir } from './build/config.ts'
 Deno.copyFileSync('LICENSE', `${baseBuildDir}/LICENSE`)
 Deno.copyFileSync('README.md', `${baseBuildDir}/README.md`)
 
-// Install build-only dependencies (bun-plugin-dts and its peers) with the
-// TypeScript version pinned in ./build/package.json. This is required because
-// dts-bundle-generator@9.5.1 declares typescript: ">=5.0.2" and, without a
-// local package.json, Bun resolves that range to the TypeScript 7 native
-// rewrite (which does not expose the legacy JS compiler API used by the
-// plugin, in particular ts.sys), breaking the .d.ts bundle step.
+// Install build-only dependencies with TypeScript pinned in ./build/package.json:
+// dts-bundle-generator needs the legacy TS JS API (ts.sys), absent from TS 7 which
+// Bun would otherwise resolve from its ">=5.0.2" range.
 console.time('Bun install time')
 const bunInstall = new Deno.Command('bun', {
   args: ['install', '--cwd', './build', '--no-progress', '--no-summary'],


### PR DESCRIPTION
## Problem

`deno task bundle` fails on `master` (independent of any dependency PR):

```
TypeError: undefined is not an object (evaluating 'ts.sys.getCurrentDirectory')
  at dts-bundle-generator@9.5.1/dist/helpers/check-diagnostics-errors.js:8
Bun build failed → bundle.ts
```

## Root cause

`build/bun-build.ts` loads `bun-plugin-dts@0.4.0` → `dts-bundle-generator@9.5.1`, which reads `ts.sys` at module-evaluation time. `dts-bundle-generator` declares `typescript: ">=5.0.2"`, and since the repo has no root `package.json`/lockfile, Bun resolves that range to **TypeScript 7** (the native `tsgo` rewrite), which does not expose the legacy JS compiler API — so `ts.sys` is `undefined`.

Verified: without a local `package.json`, `require('typescript').version === '7.0.2'` and `ts.sys === undefined`; pinned to `^5`, `ts.version === '5.9.3'` and `ts.sys.getCurrentDirectory` is a function.

## Fix

Add a build-only `build/package.json` (`private: true`) pinning `typescript: ^5.9.3`, and run `bun install --cwd ./build` in `bundle.ts` before the Bun build. No source code touched; the Deno-first publish flow is unchanged (`deno.json` `publish.include` does not include `package.json`).

## Verification

| Command | Result |
|---|---|
| `deno task bundle` (cold + warm) | exit 0, `dist/esm/mod.d.ts` (2288 lines) regenerated |
| resolved TypeScript | `5.9.3` |
| `deno fmt --check` / `deno lint` | exit 0 |
