### PR TITLE
fix(build): constrain TypeScript compiler API

### DIFF
--- a/build/bun.lock
+++ b/build/bun.lock
@@ -11,6 +11,9 @@
       },
     },
   },
+  "overrides": {
+    "typescript": "5.9.3",
+  },
   "packages": {
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/build/package.json
+++ b/build/package.json
@@ -8,5 +8,8 @@
     "bun-plugin-dts": "^0.4.0",
     "dts-bundle-generator": "^9.5.1",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] Title follows Conventional Commits.
- [x] Added a build-only dependency constraint and updated the Bun lockfile.
- [x] Existing tests pass; no product behavior changed.
- [x] No user-facing feature documentation required.
- [x] Addresses the build failure exposed by #164 and the incompatibility visible in #155.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Root cause

`dts-bundle-generator@9.5.1` accepts `typescript >=5.0.2`, but TypeScript 7 does not expose the compiler API it calls (`ts.sys`). A lock refresh could therefore resolve an incompatible nested TypeScript 7 package.

## Changes

- override all build-tree TypeScript resolutions to `5.9.3`
- record the override in `build/bun.lock`
- keep the existing declaration-generation toolchain unchanged

## Verification

- `bunx bun@1.4.0 install --frozen-lockfile`
- Bun 1.4.0 browser and Bun build scripts
- `deno task test`: 17 passed, 250 steps, 0 failed
- `deno task format:check`
- `deno task lint`