### PR TITLE
ci!: test supported Deno release channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,9 @@ permissions:
   checks: read
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
-        deno: [v1.x, v2.x, canary]
-
-    name: Deno ${{ matrix.deno }} on ${{ matrix.os }}
-
-    runs-on: ${{ matrix.os }}
+  quality:
+    name: Quality and coverage
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -29,32 +23,21 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis. This is needed for better sonar
 
-      - name: Setup Deno ${{ matrix.deno }}
+      - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: ${{ matrix.deno }}
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+          deno-version: latest
 
       - name: Format Check
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.deno == 'v2.x' }}
         run: deno task format:check
 
       - name: Lint
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.deno == 'v2.x' }}
         run: deno task lint
 
       - name: Tests & Coverage
         run: deno task test:coverage
 
-      - name: Bundle
-        run: deno task bundle
-
       - name: Coverage Report
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.deno == 'v2.x' }}
         run: deno task coverage:report
 
       - name: Check for SonarCloud Token Availability
@@ -68,8 +51,68 @@ jobs:
           fi
 
       - name: SonarCloud Code Analysis
-        if: ${{ steps.sonar-token.outputs.available == 'true' && github.repository == 'poolifier/poolifier-web-worker' && matrix.os == 'ubuntu-latest' && matrix.deno == 'v2.x' }}
+        if: ${{ steps.sonar-token.outputs.available == 'true' && github.repository == 'poolifier/poolifier-web-worker' }}
         uses: sonarsource/sonarqube-scan-action@v8.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  runtime-tests:
+    name: Deno ${{ matrix.deno }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            deno: latest
+            experimental: false
+          - os: macos-latest
+            deno: latest
+            experimental: false
+          - os: ubuntu-latest
+            deno: lts
+            experimental: false
+          - os: ubuntu-latest
+            deno: canary
+            experimental: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Deno ${{ matrix.deno }}
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.deno }}
+
+      - name: Tests
+        run: deno task test
+
+  bundle:
+    name: Bundle on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: latest
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Bundle
+        run: deno task bundle

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: latest
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: latest
 
       - name: Publish Release
         if: ${{ contains(github.ref_name, '-') == false }}
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: latest
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Remember that workers can only send and receive structured-cloneable data.
 
 ## Deno and Bun versions
 
-- Deno versions >= 1.40.x are supported.
+- The latest stable and active LTS Deno releases are supported.
 - Bun versions >= 1.x are supported.
 
 ## [API](https://github.com/poolifier/poolifier-web-worker/blob/master/docs/api.md)


### PR DESCRIPTION
## PR Checklist

- [x] Title follows Conventional Commits.
- [x] Separated runtime, quality, bundle, and release responsibilities.
- [x] Exercised every blocking command locally.
- [x] Updated the documented Deno support policy.
- [x] Follows up on the Deno v1 CI RCA.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Deno 1 is no longer supported. Consumers must use the latest stable Deno release or an active Deno LTS release.

## Changes

- run quality checks, coverage, and Sonar once on Ubuntu with latest stable Deno
- test latest stable Deno on macOS and Windows and active LTS on Ubuntu
- run Deno canary on Ubuntu as an advisory, non-blocking job
- keep cross-platform bundle validation in a separate Bun-labelled matrix
- disable runtime and bundle matrix fail-fast so failures remain attributable
- use latest stable Deno consistently for release build and publication jobs
- document support for latest stable and active LTS Deno releases

## Verification

- parsed both workflows and asserted the CI job contracts, advisory canary configuration, and latest Deno release toolchain
- `deno task format:check`
- `deno task lint`
- `deno task test:coverage`: 17 passed, 250 steps, 0 failed
- `deno task coverage:report`
- `deno task bundle`