### PR TITLE
ci: use default GitHub token for releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.WORKFLOW_TOKEN }}
           config-file: .github/release-please/config.json
           manifest-file: .github/release-please/manifest.json
 


### PR DESCRIPTION
## PR Checklist

- [x] Title follows Conventional Commits.
- [x] Removed the obsolete custom token reference.
- [x] Validated the workflow and repository Actions settings.
- [x] No product behavior or documentation change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Changes

- let `googleapis/release-please-action@v5` use its default `github.token`
- remove the final repository reference to `WORKFLOW_TOKEN`

## Repository settings

- default workflow permissions: `write`
- Actions may create and approve pull requests
- no repository `WORKFLOW_TOKEN` secret or variable remains

## Verification

- parsed `release-please.yml` and asserted that no explicit token input remains
- repository-wide `WORKFLOW_TOKEN` search: no matches
- `deno task format:check`

GitHub does not recursively trigger workflows for events created with the default token; this is the expected consequence of removing the custom workflow token.