### PR TITLE
ci: dispatch checks for release pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,19 @@ on:
   merge_group:
     branches: [master]
   workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Pull request number
+        required: true
+        type: string
+      head_ref:
+        description: Pull request head branch
+        required: true
+        type: string
+      base_ref:
+        description: Pull request base branch
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -54,6 +67,9 @@ jobs:
       - name: SonarCloud Code Analysis
         if: ${{ steps.sonar-token.outputs.available == 'true' && github.repository == 'poolifier/poolifier-web-worker' }}
         uses: sonarsource/sonarqube-scan-action@v8.2
+        with:
+          args: >-
+            ${{ github.event_name == 'workflow_dispatch' && format('-Dsonar.pullrequest.key={0} -Dsonar.pullrequest.branch={1} -Dsonar.pullrequest.base={2}', inputs.pull_request, inputs.head_ref, inputs.base_ref) || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, synchronize, reopened]
   merge_group:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Dispatch CI for release pull request
         if: ${{ steps.release.outputs.prs_created == 'true' }}
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,12 +32,19 @@ jobs:
       - name: Dispatch CI for release pull request
         if: ${{ steps.release.outputs.prs_created == 'true' }}
         env:
-          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
+          pull_request=$(jq -r '.number' <<< "$RELEASE_PR")
+          head_ref=$(jq -r '.headBranchName' <<< "$RELEASE_PR")
+          base_ref=$(jq -r '.baseBranchName' <<< "$RELEASE_PR")
+
           gh workflow run ci.yml \
-            --ref "$(jq -r '.headBranchName' <<< "$RELEASE_PR")"
+            --repo "${{ github.repository }}" \
+            --ref "$head_ref" \
+            --raw-field pull_request="$pull_request" \
+            --raw-field head_ref="$head_ref" \
+            --raw-field base_ref="$base_ref"
 
   build-release:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,9 @@ jobs:
     if: github.repository == 'poolifier/poolifier-web-worker'
 
     permissions:
+      actions: write
       contents: write
+      issues: write
       pull-requests: write
 
     outputs:
@@ -26,6 +28,15 @@ jobs:
         with:
           config-file: .github/release-please/config.json
           manifest-file: .github/release-please/manifest.json
+
+      - name: Dispatch CI for release pull request
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
+        run: |
+          gh workflow run ci.yml \
+            --ref "$(jq -r '.headBranchName' <<< "$RELEASE_PR")"
 
   build-release:
     needs: release-please


### PR DESCRIPTION
## PR Checklist

- [x] Title follows Conventional Commits.
- [x] Restores automatic required checks without a custom token.
- [x] Preserves SonarCloud pull-request analysis on dispatched runs.
- [x] Uses least-privilege job permissions.
- [x] Validated workflow structure and formatting.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Problem

Resources created with the default `GITHUB_TOKEN` do not emit recursive workflow runs. A plain dispatch can run CI on the release branch, but `workflow_dispatch` has no native pull-request event context for SonarCloud.

## Changes

- enable `workflow_dispatch` with required string inputs for PR number, head ref, and base ref
- grant the Release Please job `actions: write` plus the documented release permissions
- extract the three values once from the Release Please PR output
- dispatch CI with explicit `--repo`, the release PR head ref, and string-safe `--raw-field` inputs
- provide conditional `sonar.pullrequest.key`, `sonar.pullrequest.branch`, and `sonar.pullrequest.base` arguments on dispatched runs

## Verification

- parsed both workflows and asserted the shared dispatch contract, permissions, and conditional Sonar arguments
- exercised extraction of PR #144 metadata from the Release Please output shape
- verified explicit GitHub CLI repository resolution
- `deno task format:check`
- `git diff --check`

The flow uses the default short-lived token and does not reintroduce a PAT or repository token secret.